### PR TITLE
Add missing `--rm` option to bin/phpstan

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run php vendor/bin/phpstan "$@"
+docker compose run --rm php vendor/bin/phpstan "$@"


### PR DESCRIPTION
It's the only bin script that runs docker compose without `--rm`, thus I assume it's an oversight.